### PR TITLE
Windows API related codes are wrapped with if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) condition

### DIFF
--- a/source/Src/ExceptionHandling/ExceptionFormatter.cs
+++ b/source/Src/ExceptionHandling/ExceptionFormatter.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Specialized;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Principal;
 using System.Threading;
@@ -81,7 +82,10 @@ namespace Microsoft.Practices.EnterpriseLibrary.ExceptionHandling
                     this.additionalInfo.Add("FullName", Assembly.GetExecutingAssembly().FullName);
                     this.additionalInfo.Add("AppDomainName", AppDomain.CurrentDomain.FriendlyName);
                     this.additionalInfo.Add("ThreadIdentity", GetThreadIdentity());
-                    this.additionalInfo.Add("WindowsIdentity", GetWindowsIdentity());
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        this.additionalInfo.Add("WindowsIdentity", GetWindowsIdentity());
+                    }
                 }
 
                 return this.additionalInfo;

--- a/source/Src/ExceptionHandling/ExceptionFormatter.cs
+++ b/source/Src/ExceptionHandling/ExceptionFormatter.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Practices.EnterpriseLibrary.ExceptionHandling
             string threadIdentity = String.Empty;
             try
             {
-                threadIdentity = Thread.CurrentPrincipal.Identity.Name;
+                threadIdentity = Thread.CurrentPrincipal?.Identity?.Name;
             }
             catch (SecurityException)
             {

--- a/source/Src/ExceptionHandling/ExceptionHandling.csproj
+++ b/source/Src/ExceptionHandling/ExceptionHandling.csproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <ProjectReference Include="$(EntLibCommon)" Condition="Exists('$(EntLibCommon)') AND '$(EntLibDependencyType)' == 'Project'" />
     <PackageReference Include="$(PrePackageName).Common$(PostPackageName)" Version="$(EntLibCommonVersion)" Condition="!Exists('$(EntLibCommon)') OR '$(EntLibDependencyType)' == 'Package'" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) OR $(TargetFramework.StartsWith('netcoreapp'))">


### PR DESCRIPTION
Windows API related codes are wrapped with if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) condition.
Tested with .net core 3.1 on Linux and Windows environments.